### PR TITLE
Add fuller validation and defaults, bump to 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.2
+  - 2.2.2
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ require 'aba'
 # Initialise ABA
 aba = Aba.new(
   bsb: "123-345", # Optional (Not required by NAB)
-  financial_institution: "WPC", 
+  financial_institution: "WPC",
   user_name: "John Doe",
-  user_id: "466364", 
-  description: "Payroll", 
+  user_id: "466364",
+  description: "Payroll",
   process_at: Time.now.strftime("%d%m%y")
 )
 
@@ -23,14 +23,14 @@ aba = Aba.new(
 10.times do
   aba.add_transaction(
     Aba::Transaction.new(
-      bsb: "342-342", 
-      account_number: "3244654", 
+      bsb: "342-342",
+      account_number: "3244654",
       amount: 10000, # Amount in cents
-      account_name: "John Doe", 
+      account_name: "John Doe",
       transaction_code: 53,
-      lodgement_reference: "R435564", 
-      trace_bsb: "453-543", 
-      trace_account_number: "45656733", 
+      lodgement_reference: "R435564",
+      trace_bsb: "453-543",
+      trace_account_number: "45656733",
       name_of_remitter: "Remitter"
     )
   )
@@ -38,6 +38,53 @@ end
 
 puts aba.to_s # View output
 File.write("/Users/me/dd_#{Time.now.to_i}.aba", aba.to_s) # or write output to file
+```
+
+Validation errors can be caught in several ways:
+
+```ruby
+aba = Aba.new(
+  user_name: "Jøhn Doe" # Invalid character
+)
+
+# Gets errors on the parent object only
+puts aba.get_errors
+
+# Returns:
+# ["user_name must not contain invalid characters",
+#  "user_id must be an unsigned integer",
+#  "financial_institution length must be exactly 3 characters",
+#  "process_at length must be exactly 6 characters",
+#  "process_at must be an unsigned integer"]
+
+
+aba.add_transaction(
+  Aba::Transaction.new(
+    bsb: "abc-123" # Bad BSB
+  )
+)
+
+# Gets errors on the contained transaction objects
+puts aba.get_transaction_errors
+
+# Returns:
+# {0=>
+#   ["bsb format is incorrect",
+#    "trace_bsb format is incorrect",
+#    "amount must be an integer",
+#    "account_number must be a valid account number",
+#    "indicator must be a one of ' ', 'N', 'T', 'W', 'X', 'Y'",
+#    "transaction_code must be a one of 50, 53, 54, 56, 57, 13"]}
+
+
+# Setting the optional validate parameter to true will suppress output if the
+# data does not validate
+
+puts aba.to_s(true)
+
+# Returns:
+# ""
+
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -70,14 +70,12 @@ puts aba.get_transaction_errors
 # Returns:
 # {0=>
 #   ["bsb format is incorrect",
-#    "trace_bsb format is incorrect",
-#    "amount must be an integer",
 #    "account_number must be a valid account number",
-#    "indicator must be a one of ' ', 'N', 'T', 'W', 'X', 'Y'",
-#    "transaction_code must be a one of 50, 53, 54, 56, 57, 13"]}
+#    "trace_bsb format is incorrect",
+#    "trace_account_number must be a valid account number"]}
 
 
-# Setting the optional validate parameter to true will suppress output if the
+# Setting the optional validate parameter to true will an empty string if the
 # data does not validate
 
 puts aba.to_s(true)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ aba = Aba.new(
 # Add transactions
 10.times do
   aba.add_transaction(
-    Aba::Transaction.new(
+    {
       bsb: "342-342",
       account_number: "3244654",
       amount: 10000, # Amount in cents
@@ -32,7 +32,7 @@ aba = Aba.new(
       trace_bsb: "453-543",
       trace_account_number: "45656733",
       name_of_remitter: "Remitter"
-    )
+    }
   )
 end
 
@@ -43,47 +43,40 @@ File.write("/Users/me/dd_#{Time.now.to_i}.aba", aba.to_s) # or write output to f
 Validation errors can be caught in several ways:
 
 ```ruby
+# Create an ABA object with invalid character in the user_name
 aba = Aba.new(
-  user_name: "Jøhn Doe" # Invalid character
+  financial_institution: "ANZ",
+  user_name: "Jøhn Doe",
+  user_id: "123456",
+  process_at: Time.now.strftime("%d%m%y")
 )
 
-# Gets errors on the parent object only
-puts aba.get_errors
 
-# Returns:
-# ["user_name must not contain invalid characters",
-#  "user_id must be an unsigned integer",
-#  "financial_institution length must be exactly 3 characters",
-#  "process_at length must be exactly 6 characters",
-#  "process_at must be an unsigned integer"]
-
-
+# Add a transaction with a bad BSB
 aba.add_transaction(
-  Aba::Transaction.new(
-    bsb: "abc-123" # Bad BSB
-  )
+  bsb: "abc-123",
+  account_number: "000123456"
 )
 
-# Gets errors on the contained transaction objects
-puts aba.get_transaction_errors
+
+# Is the data valid?
+aba.all_valid?
+
+# Returns: false
+
+
+# Return a structured array of errors
+puts aba.all_errors
 
 # Returns:
-# {0=>
-#   ["bsb format is incorrect",
-#    "account_number must be a valid account number",
-#    "trace_bsb format is incorrect",
-#    "trace_account_number must be a valid account number"]}
-
-
-# Setting the optional validate parameter to true will an empty string if the
-# data does not validate
-
-puts aba.to_s(true)
-
-# Returns:
-# ""
-
+# {:aba => ["user_name must not contain invalid characters"],
+#  :transactions =>
+#   {0 => ["bsb format is incorrect", "trace_bsb format is incorrect"]}}
 ```
+
+Validation errors will stop parsing of the data to an ABA formatted string using
+`to_s`. `aba.to_s` will raise a `RuntimeError` instead of returning output.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[ ![Codeship Status for krakendevelopments/aba](https://codeship.com/projects/982382f0-f22b-0132-a80d-0acc257ded9c/status?branch=master)](https://codeship.com/projects/85083)
+[![Build Status](https://travis-ci.org/andrba/aba.svg?branch=master)](https://travis-ci.org/andrba/aba) [![Code Climate](https://codeclimate.com/github/andrba/aba/badges/gpa.svg)](https://codeclimate.com/github/andrba/aba)
 
 # Aba
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ puts aba.to_s # View output
 File.write("/Users/me/dd_#{Time.now.to_i}.aba", aba.to_s) # or write output to file
 ```
 
+There are a few ways to create a complete set of ABA data:
+
+```ruby
+# Transactions added to the defined ABA object variable
+aba = Aba.new financial_institution: 'ANZ', user_name: 'Joe Blow', user_id: 123456, process_at: 200615
+aba.add_transaction bsb: '123-456', account_number: '000-123-456', amount: 50000
+aba.add_transaction bsb: '456-789', account_number: '123-456-789', amount: '-10000'
+
+# Transactions passed individually inside a block
+aba = Aba.new financial_institution: 'ANZ', user_name: 'Joe Blow', user_id: 123456, process_at: 200615 do |a|
+  a.add_transaction bsb: '123-456', account_number: '000-123-456', amount: 50000
+  a.add_transaction bsb: '456-789', account_number: '123-456-789', amount: '-10000'
+end
+
+# Transactions as an array passed to the second param of Aba.new()
+aba = Aba.new(
+  { financial_institution: 'ANZ', user_name: 'Joe Blow', user_id: 123456, process_at: 200615 },
+  [
+    { bsb: '123-456', account_number: '000-123-456', amount: 50000 },
+    { bsb: '456-789', account_number: '123-456-789', amount: '-10000' }
+  ]
+)
+```
+
 Validation errors can be caught in several ways:
 
 ```ruby
@@ -51,23 +75,18 @@ aba = Aba.new(
   process_at: Time.now.strftime("%d%m%y")
 )
 
-
 # Add a transaction with a bad BSB
 aba.add_transaction(
   bsb: "abc-123",
   account_number: "000123456"
 )
 
-
 # Is the data valid?
 aba.all_valid?
-
 # Returns: false
-
 
 # Return a structured array of errors
 puts aba.all_errors
-
 # Returns:
 # {:aba => ["user_name must not contain invalid characters"],
 #  :transactions =>

--- a/aba.gemspec
+++ b/aba.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.4"
-  spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rspec", "~> 3.0"
+
+  spec.add_runtime_dependency "pry", "~> 0.10", ">= 0.10.1"
 
   spec.required_ruby_version = '>= 1.9.2'
 end

--- a/aba.gemspec
+++ b/aba.gemspec
@@ -20,9 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.4"
+  spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rspec", "~> 3.0"
-
-  spec.add_runtime_dependency "pry", "~> 0.10", ">= 0.10.1"
 
   spec.required_ruby_version = '>= 1.9.2'
 end

--- a/lib/aba.rb
+++ b/lib/aba.rb
@@ -32,7 +32,7 @@ class Aba
   validates_integer     :process_at, false
 
 
-  def initialize(attrs = {})
+  def initialize(attrs = {}, transactions = [])
     attrs.each do |key, value|
       send("#{key}=", value)
     end
@@ -40,12 +40,14 @@ class Aba
     @transaction_index = 0
     @transactions = {}
 
+    transactions.to_a.each{ |t| self.add_transaction(t) } unless transactions.nil? || transactions.empty?
+
     yield self if block_given?
   end
 
   def to_s
     raise RuntimeError, 'No transactions present - add one using `add_transaction`' if @transactions.empty?
-    raise RuntimeError, 'Aba data is invalid - check the contents of `all_errors`' unless valid?
+    raise RuntimeError, 'ABA data is invalid - check the contents of `all_errors`' unless valid?
 
     # Descriptive record
     output = "#{descriptive_record}\r\n"
@@ -157,9 +159,9 @@ class Aba
     debit_total_amount  = 0
 
     @transactions.each do |t|
-      net_total_amount += t[1].amount
-      credit_total_amount += t[1].amount if t[1].amount > 0
-      debit_total_amount += t[1].amount if t[1].amount < 0
+      net_total_amount += t[1].amount.to_i
+      credit_total_amount += t[1].amount.to_i if t[1].amount.to_i > 0
+      debit_total_amount += t[1].amount.to_i if t[1].amount.to_i < 0
     end
 
     # Record type

--- a/lib/aba/transaction.rb
+++ b/lib/aba/transaction.rb
@@ -54,9 +54,9 @@ class Aba
       @indicator || Aba::Validations::INDICATORS.first
     end
 
-    # Fall back to 53
+    # Fall back to 50
     def transaction_code
-      @transaction_code || Aba::Validations::TRANSACTION_CODES.first
+      @transaction_code || 50
     end
 
     # Fall back to 0
@@ -119,7 +119,7 @@ class Aba
       output += transaction_code.to_s
 
       # Amount to be credited or debited
-      output += amount.abs.to_s.rjust(10, "0")
+      output += amount.to_i.abs.to_s.rjust(10, "0")
 
       # Title of Account
       # Full BECS character set valid

--- a/lib/aba/transaction.rb
+++ b/lib/aba/transaction.rb
@@ -2,29 +2,73 @@ class Aba
   class Transaction
     include Aba::Validations
 
-    attr_accessor :account_number, :transaction_code, :amount, :account_name, 
+    attr_accessor :account_number, :transaction_code, :amount, :account_name,
                   :bsb, :trace_bsb, :trace_account_number, :name_of_remitter,
                   :witholding_amount, :indicator, :lodgement_reference
 
-    validates_bsb :bsb
-    validates_bsb :trace_bsb
-    
-    validates_integer :amount
+    # BSB
+    validates_bsb               :bsb
 
-    validates_max_length :account_number,         9
-    validates_max_length :indicator,              1
-    validates_max_length :transaction_code,       2
-    validates_max_length :account_name,           32
-    validates_max_length :lodgement_reference,    18
-    validates_max_length :trace_account_number,   9
-    validates_max_length :name_of_remitter,       16
+    # Account Number
+    validates_account_number    :account_number
+
+    # Indicator
+    validates_indicator         :indicator
+
+    # Transaction Code
+    validates_transaction_code  :transaction_code
+
+    # Amount
+    validates_integer           :amount
+
+    # Account Name
+    validates_max_length        :account_name, 32
+    validates_becs              :account_name
+
+    # Lodgement Reference
+    validates_max_length        :lodgement_reference, 18
+    validates_becs              :lodgement_reference
+
+    # Trace Record
+    validates_bsb               :trace_bsb
+    validates_account_number    :trace_account_number
+
+    # Name of Remitter
+    validates_max_length        :name_of_remitter, 16
+    validates_becs              :name_of_remitter
+
 
     def initialize(attrs = {})
       attrs.each do |key, value|
         send("#{key}=", value)
       end
     end
-    
+
+    # Fall back to blank string
+    def indicator
+      @indicator || ' '
+    end
+
+    # Fall back to 53
+    def transaction_code
+      @transaction_code || 53
+    end
+
+    # Fall back to 0
+    def amount
+      @amount || 0
+    end
+
+    # Fall back to BSB
+    def trace_bsb
+      @trace_bsb || bsb
+    end
+
+    # Fall back to Account Number
+    def trace_account_number
+      @trace_account_number || account_number
+    end
+
     def to_s
       # Record type
       output = "1"
@@ -37,17 +81,18 @@ class Aba
 
       # Withholding Tax Indicator
       # "N" – for new or varied Bank/State/Branch number or name details, otherwise blank filled.
+      # "T" - for a drawing under a Transaction Negotiation Authority.
       # "W" – dividend paid to a resident of a country where a double tax agreement is in force.
       # "X" – dividend paid to a resident of any other country.
       # "Y" – interest paid to all non-residents.
       output += indicator.to_s.ljust(1, " ")
 
       # Transaction Code
-      # 50 General Credit. 
-      # 53 Payroll. 
-      # 54 Pension. 
-      # 56 Dividend. 
-      # 57 Debenture Interest. 
+      # 50 General Credit.
+      # 53 Payroll.
+      # 54 Pension.
+      # 56 Dividend.
+      # 57 Debenture Interest.
       # 13 General Debit.
       output += transaction_code.to_s
 
@@ -55,18 +100,21 @@ class Aba
       output += amount.abs.to_s.rjust(10, "0")
 
       # Title of Account
+      # Full BECS character set valid
       output += account_name.ljust(32, " ")
 
-      # Lodgement Reference Produced on the recipient’s Account Statement. 
-      output += lodgement_reference.ljust(18, " ")     
+      # Lodgement Reference Produced on the recipient’s Account Statement.
+      # Full BECS character set valid
+      output += lodgement_reference.ljust(18, " ")
 
       # Trace BSB Number
       output += trace_bsb
 
-      # Trace Account Number 
+      # Trace Account Number
       output += trace_account_number.to_s.rjust(9, " ")
 
       # Name of Remitter Produced on the recipient’s Account Statement
+      # Full BECS character set valid
       output += name_of_remitter.ljust(16, " ")
 
       # Withholding amount in cents

--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -1,5 +1,4 @@
 class Aba
-  require 'pry'
   module Validations
     attr_accessor :errors
 

--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -5,7 +5,6 @@ class Aba
 
     BECS_PATTERN = /\A[\w\+\-\@\ \$\!\%\&\(\)\*\.\/\#\=\:\;\?\,\'\[\]\_\^]*\Z/
     INDICATORS = [' ', 'N', 'T', 'W', 'X', 'Y']
-    TRANSACTION_CODES = [50, 53, 54, 56, 57, 13]
 
     def self.included(base)
       base.instance_eval do
@@ -36,9 +35,9 @@ class Aba
             self.errors << "#{attribute} length must be exactly #{param} characters" if value.to_s.length != param
           when :integer
             if param
-              self.errors << "#{attribute} must be an integer" unless value.to_s =~ /\A[+-]?\d+\Z/
+              self.errors << "#{attribute} must be a number" unless value.to_s =~ /\A[+-]?\d+\Z/
             else
-              self.errors << "#{attribute} must be an unsigned integer" unless value.to_s =~ /\A\d+\Z/
+              self.errors << "#{attribute} must be an unsigned number" unless value.to_s =~ /\A\d+\Z/
             end
           when :account_number
             if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-z\d\ ]{1,9}\Z/
@@ -50,8 +49,7 @@ class Aba
             list = INDICATORS.join('\', \'')
             self.errors << "#{attribute} must be a one of '#{list}'" unless INDICATORS.include?(value.to_s)
           when :transaction_code
-            list = TRANSACTION_CODES.join(', ')
-            self.errors << "#{attribute} must be a one of #{list}" unless TRANSACTION_CODES.include?(value.to_i)
+            self.errors << "#{attribute} must be a 2 digit number" unless value.to_s =~ /\A\d{2,2}\Z/
           end
         end
       end

--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -17,7 +17,7 @@ class Aba
 
     # Run all validations
     def valid?
-      errors = []
+      self.errors = []
 
       self.class.instance_variable_get(:@_validations).each do |attribute, validations|
         value = send(attribute)
@@ -25,45 +25,38 @@ class Aba
         validations.each do |type, param|
           case type
           when :presence
-            errors << "#{attribute} is empty" if value.nil? || value.to_s.empty?
+            self.errors << "#{attribute} is empty" if value.nil? || value.to_s.empty?
           when :bsb
             unless((param && value.nil?) || value =~ /^\d{3}-\d{3}$/)
-              errors << "#{attribute} format is incorrect"
+              self.errors << "#{attribute} format is incorrect"
             end
           when :max_length
-            errors << "#{attribute} length must not exceed #{param} characters" if value.to_s.length > param
+            self.errors << "#{attribute} length must not exceed #{param} characters" if value.to_s.length > param
           when :length
-            errors << "#{attribute} length must be exactly #{param} characters" if value.to_s.length != param
+            self.errors << "#{attribute} length must be exactly #{param} characters" if value.to_s.length != param
           when :integer
             if param
-              errors << "#{attribute} must be an integer" unless value.to_s =~ /\A[+-]?\d+\Z/
+              self.errors << "#{attribute} must be an integer" unless value.to_s =~ /\A[+-]?\d+\Z/
             else
-              errors << "#{attribute} must be an unsigned integer" unless value.to_s =~ /\A\d+\Z/
+              self.errors << "#{attribute} must be an unsigned integer" unless value.to_s =~ /\A\d+\Z/
             end
           when :account_number
-            if value.to_s =~ /\A[0\ \-]+\Z/ || value.to_s !~ /\A[a-z\d\-\ ]{1,9}\Z/
-              errors << "#{attribute} must be a valid account number"
+            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-z\d\ ]{1,9}\Z/
+              self.errors << "#{attribute} must be a valid account number"
             end
           when :becs
-            errors << "#{attribute} must not contain invalid characters" unless value.to_s =~ BECS_PATTERN
+            self.errors << "#{attribute} must not contain invalid characters" unless value.to_s =~ BECS_PATTERN
           when :indicator
             list = INDICATORS.join('\', \'')
-            errors << "#{attribute} must be a one of '#{list}'" unless INDICATORS.include?(value.to_s)
+            self.errors << "#{attribute} must be a one of '#{list}'" unless INDICATORS.include?(value.to_s)
           when :transaction_code
             list = TRANSACTION_CODES.join(', ')
-            errors << "#{attribute} must be a one of #{list}" unless TRANSACTION_CODES.include?(value.to_i)
+            self.errors << "#{attribute} must be a one of #{list}" unless TRANSACTION_CODES.include?(value.to_i)
           end
         end
       end
-      self.errors = errors if errors.length
 
       self.errors.empty?
-    end
-
-    # Updates errors through valid? call
-    def get_errors
-      valid?
-      self.errors unless self.errors.empty?
     end
 
     module ClassMethods

--- a/lib/aba/version.rb
+++ b/lib/aba/version.rb
@@ -1,3 +1,3 @@
 class Aba
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/lib/aba/version.rb
+++ b/lib/aba/version.rb
@@ -1,3 +1,3 @@
 class Aba
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/aba_spec.rb
+++ b/spec/aba_spec.rb
@@ -1,7 +1,9 @@
+# encoding: UTF-8
+
 require "spec_helper"
 
 describe Aba do
-  let(:aba) { Aba.new(financial_institution: "WPC", user_name: "John Doe", 
+  let(:aba) { Aba.new(financial_institution: "WPC", user_name: "John Doe",
                       user_id: "466364", description: "Payroll", process_at: "190615") }
   let(:transaction_values) { [30, -20] }
   let(:transactions) do

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require "spec_helper"
 
 describe Aba::Transaction do
@@ -10,8 +12,8 @@ describe Aba::Transaction do
     :witholding_amount => 87,
     :indicator => "W",
     :lodgement_reference => "R45343",
-    :trace_bsb => "123-234", 
-    :trace_account_number => "4647642", 
+    :trace_bsb => "123-234",
+    :trace_account_number => "4647642",
     :name_of_remitter => "Remitter"
   } }
   subject(:transaction) { Aba::Transaction.new(transaction_params) }

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -82,7 +82,7 @@ describe Aba::Validations do
 
       subject.attr1 = "+1234A"
       expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be an integer"]
+      expect(subject.errors).to eq ["attr1 must be a number"]
 
       subject.attr1 = "+1234"
       expect(subject.valid?).to eq true
@@ -102,15 +102,15 @@ describe Aba::Validations do
 
       subject.attr1 = "1234A"
       expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+      expect(subject.errors).to eq ["attr1 must be an unsigned number"]
 
       subject.attr1 = "+1234"
       expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+      expect(subject.errors).to eq ["attr1 must be an unsigned number"]
 
       subject.attr1 = "-1234"
       expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+      expect(subject.errors).to eq ["attr1 must be an unsigned number"]
 
       subject.attr1 = "1234"
       expect(subject.valid?).to eq true
@@ -195,10 +195,20 @@ describe Aba::Validations do
 
       subject.attr1 = "AA"
       expect(subject.valid?).to eq false
-      list = Aba::Validations::TRANSACTION_CODES.join(', ')
-      expect(subject.errors).to eq ["attr1 must be a one of #{list}"]
+      expect(subject.errors).to eq ["attr1 must be a 2 digit number"]
 
-      subject.attr1 = Aba::Validations::TRANSACTION_CODES.sample
+      subject.attr1 = "123"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a 2 digit number"]
+
+      subject.attr1 = "1"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a 2 digit number"]
+
+      subject.attr1 = "15"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = 15
       expect(subject.valid?).to eq true
     end
   end

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require "spec_helper"
 
 describe Aba::Validations do

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Aba::Validations do
-  let(:clean_room) do 
+  let(:clean_room) do
     Class.new(Object) do
       include Aba::Validations
     end
@@ -18,6 +18,9 @@ describe Aba::Validations do
 
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 is empty"]
+
+      subject.attr1 = "hello!"
+      expect(subject.valid?).to eq true
     end
 
     it "should validate bsb format" do
@@ -27,21 +30,191 @@ describe Aba::Validations do
       end
 
       subject.attr1 = "234456"
-
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 format is incorrect"]
+
+      subject.attr1 = "234-456"
+      expect(subject.valid?).to eq true
     end
 
-    it "should validate length" do
+    it "should validate max length" do
       clean_room.instance_eval do
         attr_accessor :attr1
         validates_max_length :attr1, 5
       end
 
       subject.attr1 = "234456642"
-
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 length must not exceed 5 characters"]
+
+      subject.attr1 = "23445"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "2344"
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate length" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_length :attr1, 5
+      end
+
+      subject.attr1 = "234456642"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 length must be exactly 5 characters"]
+
+      subject.attr1 = "23445"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "2344"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 length must be exactly 5 characters"]
+    end
+
+    it "should validate signed integer" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_integer :attr1
+      end
+
+      subject.attr1 = "+1234A"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be an integer"]
+
+      subject.attr1 = "+1234"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "-1234"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "1234"
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate unsigned integer" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_integer :attr1, false
+      end
+
+      subject.attr1 = "1234A"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+
+      subject.attr1 = "+1234"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+
+      subject.attr1 = "-1234"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be an unsigned integer"]
+
+      subject.attr1 = "1234"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = 1234
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate account number" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_account_number :attr1
+      end
+
+      subject.attr1 = "      "
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "000000"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "------"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "0--0-0"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "00-0 0"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "00-0A0"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+
+      subject.attr1 = "00-111"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "00 111"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "00 1-1"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "0a 1-1"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "aaaaaa"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "aa-aaa"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "aa aaa"
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate becs" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_becs :attr1
+      end
+
+      subject.attr1 = "abc123 é"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must not contain invalid characters"]
+
+      subject.attr1 = "abc123 ~"
+      expect(subject.valid?).to eq false
+      expect(subject.errors).to eq ["attr1 must not contain invalid characters"]
+
+      subject.attr1 = "abc123"
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate indicator" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_indicator :attr1
+      end
+
+      subject.attr1 = "$"
+      expect(subject.valid?).to eq false
+      list = Aba::Validations::INDICATORS.join('\', \'')
+      expect(subject.errors).to eq ["attr1 must be a one of '#{list}'"]
+
+      subject.attr1 = Aba::Validations::INDICATORS.sample
+      expect(subject.valid?).to eq true
+    end
+
+    it "should validate transaction code" do
+      clean_room.instance_eval do
+        attr_accessor :attr1
+        validates_transaction_code :attr1
+      end
+
+      subject.attr1 = "AA"
+      expect(subject.valid?).to eq false
+      list = Aba::Validations::TRANSACTION_CODES.join(', ')
+      expect(subject.errors).to eq ["attr1 must be a one of #{list}"]
+
+      subject.attr1 = Aba::Validations::TRANSACTION_CODES.sample
+      expect(subject.valid?).to eq true
     end
   end
 end

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -131,38 +131,21 @@ describe Aba::Validations do
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
 
-      subject.attr1 = "------"
+      subject.attr1 = "00 0 0"
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
 
-      subject.attr1 = "0--0-0"
+      subject.attr1 = "00 0A0"
       expect(subject.valid?).to eq false
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
-
-      subject.attr1 = "00-0 0"
-      expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be a valid account number"]
-
-      subject.attr1 = "00-0A0"
-      expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be a valid account number"]
-
-      subject.attr1 = "00-111"
-      expect(subject.valid?).to eq true
 
       subject.attr1 = "00 111"
       expect(subject.valid?).to eq true
 
-      subject.attr1 = "00 1-1"
-      expect(subject.valid?).to eq true
-
-      subject.attr1 = "0a 1-1"
+      subject.attr1 = "0a 111"
       expect(subject.valid?).to eq true
 
       subject.attr1 = "aaaaaa"
-      expect(subject.valid?).to eq true
-
-      subject.attr1 = "aa-aaa"
       expect(subject.valid?).to eq true
 
       subject.attr1 = "aa aaa"


### PR DESCRIPTION
This incorporates BECS character validation and account number validation on relevant fields.

Also allows easier access to transaction objects, and their errors.

Also adds an optional parameter to `Aba.to_s` which will suppress output if the data is not valid.

Also changes pry gem to a runtime dependency, as it is included in the validations module.
