### PR TITLE
Allow uppercase alpha characters in account number

### DIFF
--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -53,7 +53,7 @@ class Aba
               self.error_collection << "#{attribute} must be an unsigned number" unless value.to_s =~ /\A\d+\Z/
             end
           when :account_number
-            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-z\d\ ]{1,9}\Z/
+            if value.to_s =~ /\A[0\ ]+\Z/ || value.to_s !~ /\A[a-z\d\ ]{1,9}\Z/i
               self.error_collection << "#{attribute} must be a valid account number"
             end
           when :becs

--- a/spec/lib/aba/validations_spec.rb
+++ b/spec/lib/aba/validations_spec.rb
@@ -138,8 +138,7 @@ describe Aba::Validations do
       expect(subject.errors).to eq ["attr1 must be a valid account number"]
 
       subject.attr1 = "00 0A0"
-      expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["attr1 must be a valid account number"]
+      expect(subject.valid?).to eq true
 
       subject.attr1 = "00 111"
       expect(subject.valid?).to eq true
@@ -151,6 +150,9 @@ describe Aba::Validations do
       expect(subject.valid?).to eq true
 
       subject.attr1 = "aa aaa"
+      expect(subject.valid?).to eq true
+
+      subject.attr1 = "1A2B3C"
       expect(subject.valid?).to eq true
     end
 


### PR DESCRIPTION
## Why
BECS account number spec does not specify any particular case of alpha characters (a-z or A_Z).

>Alpha (26 letters of the alphabet), numeric, hyphens & blanks
only are valid. Must not contain all blanks or all zeros.
Leading zeros, which are part of an account number must be
shown. (Some Financial Institutions have leading zeros in valid
account numbers, ie 00-1234.) Edit out hyphens where account
number exceeds nine characters. Right justified. Blank filled

## What
Update validation for account numbers to allow uppercase A-Z

It currently only allows lowercase a-z