### PR TITLE
Validate amount length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog
+
+## v1.0.1, 19 July 2022
+
+### Added
+
+- Enforce ABA validation: amount (in cents) cannot exceed 10 characters.
+- Enforce ABA validation: total amount (in cents) cannot exceed 10 characters.
+
 ## v1.0.0, 12 July 2020
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## v1.0.1, 19 July 2022
+## v1.0.1, 25 July 2022
 
 ### Added
 
-- Enforce ABA validation: amount (in cents) cannot exceed 10 characters.
-- Enforce ABA validation: total amount (in cents) cannot exceed 10 characters.
+- Enforce ABA validation:
+  - Amount (in cents) cannot exceed 10 characters.
+  - Total debit amount (in cents) cannot exceed 10 characters.
+  - Total credit amount (in cents) cannot exceed 10 characters.
 
 ## v1.0.0, 12 July 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ### BREAKING CHANGES
 
-* Positive (`n`) and negative (`-n`) values are now treated the same.
-  e.g `5` and `-5` are both processed as `5`, without any signage.
-  To differentiate between a debit and credit, use the correct [Transaction Code](https://github.com/andrba/aba/blob/58446f5b0ef822e9792e9399b4af647319b13515/lib/aba/transaction.rb#L106-L112)
-* Removed default values for transactions records to avoid generation of potentially incorrect records. Safety first!
-* Minimum Ruby version is now 2.5
+- Positive (`n`) and negative (`-n`) values are now treated the same. e.g `5`
+  and `-5` are both processed as `5`, without any signage. To differentiate
+  between a debit and credit, use the correct [Transaction
+  Code](https://github.com/andrba/aba/blob/58446f5b0ef822e9792e9399b4af647319b13515/lib/aba/transaction.rb#L106-L112)
+- Removed default values for transactions records to avoid generation of
+  potentially incorrect records. Safety first!
+- Minimum Ruby version is now 2.5
 
 ### NEW FEATURE
 
-* You can now add a *return* record to be used when you'd like to return
-a credit or a debit to another financial institution (OFI).
+- You can now add a *return* record to be used when you'd like to return a
+  credit or a debit to another financial institution (OFI).

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in aba.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 

--- a/aba.gemspec
+++ b/aba.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/lib/aba.rb
+++ b/lib/aba.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "aba/version"
 require "aba/validations"
 require "aba/entry"

--- a/lib/aba/batch.rb
+++ b/lib/aba/batch.rb
@@ -30,8 +30,6 @@ class Aba
     validates_length      :process_at, 6
     validates_integer     :process_at, false
 
-    # Total
-    validates_max_length  :total, 10
 
     def initialize(attrs = {}, transactions = [])
       attrs.each do |key, value|
@@ -69,10 +67,6 @@ class Aba
 
     def add_return(attrs = {})
       add_entry(Aba::Return, attrs)
-    end
-
-    def total
-      transactions.sum { |t| t.amount.to_i }
     end
 
     def transactions

--- a/lib/aba/batch.rb
+++ b/lib/aba/batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   class Batch
     include Aba::Validations

--- a/lib/aba/batch.rb
+++ b/lib/aba/batch.rb
@@ -92,7 +92,10 @@ class Aba
       # Build errors
       all_errors = {}
       all_errors[:aba] = self.error_collection unless self.error_collection.empty?
-      entry_error_collection = entries.each_with_index.map { |t, i| [i, t.error_collection] }.reject { |e| e[1].nil? || e[1].empty? }.to_h
+      entry_error_collection = entries.each_with_index
+        .map { |t, i| [i, t.error_collection] }
+        .reject { |e| e[1].nil? || e[1].empty? }
+        .to_h
       all_errors[:entries] = entry_error_collection unless entry_error_collection.empty?
 
       all_errors unless all_errors.empty?

--- a/lib/aba/batch.rb
+++ b/lib/aba/batch.rb
@@ -30,6 +30,8 @@ class Aba
     validates_length      :process_at, 6
     validates_integer     :process_at, false
 
+    # Total
+    validates_max_length  :total, 10
 
     def initialize(attrs = {}, transactions = [])
       attrs.each do |key, value|
@@ -67,6 +69,10 @@ class Aba
 
     def add_return(attrs = {})
       add_entry(Aba::Return, attrs)
+    end
+
+    def total
+      transactions.sum { |t| t.amount.to_i }
     end
 
     def transactions

--- a/lib/aba/batch.rb
+++ b/lib/aba/batch.rb
@@ -173,6 +173,9 @@ class Aba
     end
 
     def batch_control_record
+      cached_credit_total_amount = credit_total_amount
+      cached_debit_total_amount = debit_total_amount
+
       # Record type
       # Max: 1
       # Char position: 1
@@ -191,17 +194,17 @@ class Aba
       # Net total
       # Max: 10
       # Char position: 21-30
-      output += (credit_total_amount - debit_total_amount).abs.to_s.rjust(10, "0")
+      output += (cached_credit_total_amount - cached_debit_total_amount).abs.to_s.rjust(10, "0")
 
       # Credit Total Amount
       # Max: 10
       # Char position: 31-40
-      output += credit_total_amount.to_s.rjust(10, "0")
+      output += cached_credit_total_amount.to_s.rjust(10, "0")
 
       # Debit Total Amount
       # Max: 10
       # Char position: 41-50
-      output += debit_total_amount.to_s.rjust(10, "0")
+      output += cached_debit_total_amount.to_s.rjust(10, "0")
 
       # Reserved
       # Max: 24
@@ -220,7 +223,7 @@ class Aba
     end
 
     def credit_total_amount
-      entries.reject(&:debit?).sum(&method(:entry_amount))
+      credit_total_amount ||= entries.reject(&:debit?).sum(&method(:entry_amount))
     end
 
     def debit_total_amount

--- a/lib/aba/entry.rb
+++ b/lib/aba/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   class Entry
     def initialize(attrs = {})

--- a/lib/aba/return.rb
+++ b/lib/aba/return.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   class Return < Entry
     include Aba::Validations

--- a/lib/aba/transaction.rb
+++ b/lib/aba/transaction.rb
@@ -22,6 +22,7 @@ class Aba
 
     # Amount
     validates_integer           :amount
+    validates_max_length        :amount, 10
 
     # Account Name
     validates_max_length        :account_name, 32

--- a/lib/aba/transaction.rb
+++ b/lib/aba/transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   class Transaction < Entry
     include Aba::Validations

--- a/lib/aba/validations.rb
+++ b/lib/aba/validations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   module Validations
     attr_accessor :error_collection

--- a/lib/aba/version.rb
+++ b/lib/aba/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Aba
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/aba/version.rb
+++ b/lib/aba/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Aba
   VERSION = "1.0.0"
 end

--- a/spec/lib/aba/batch_spec.rb
+++ b/spec/lib/aba/batch_spec.rb
@@ -131,5 +131,18 @@ describe Aba::Batch do
         expect(batch.errors).to eq(:entries => { 1 => ["amount must be a number"], 2 => ["amount must be a number"] })
       end
     end
+
+    context "with an invalid total (exceeding 10 characters)" do
+      let(:transactions_attributes) do
+        [
+          {amount: 9999999999, transaction_code: 50},
+          {amount: 9999999999, transaction_code: 50},
+        ]
+      end
+
+      it "reports the errors" do
+        expect(batch.errors).to include(aba: ["total length must not exceed 10 characters"])
+      end
+    end
   end
 end

--- a/spec/lib/aba/batch_spec.rb
+++ b/spec/lib/aba/batch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 require "spec_helper"

--- a/spec/lib/aba/batch_spec.rb
+++ b/spec/lib/aba/batch_spec.rb
@@ -131,5 +131,31 @@ describe Aba::Batch do
         expect(batch.errors).to eq(:entries => { 1 => ["amount must be a number"], 2 => ["amount must be a number"] })
       end
     end
+
+    context "with an invalid credit total (exceeding 10 characters)" do
+      let(:transactions_attributes) do
+        [
+          {amount: 9999999999, transaction_code: 50},
+          {amount: 9999999999, transaction_code: 50},
+        ]
+      end
+
+      it "reports the errors" do
+        expect(batch.errors).to include(aba: ["credit_total_amount length must not exceed 10 characters"])
+      end
+    end
+
+    context "with an invalid debit total amount (exceeding 10 characters)" do
+      let(:transactions_attributes) do
+        [
+          {amount: 9999999999, transaction_code: 13},
+          {amount: 9999999999, transaction_code: 13},
+        ]
+      end
+
+      it "reports the errors" do
+        expect(batch.errors).to include(aba: ["debit_total_amount length must not exceed 10 characters"])
+      end
+    end
   end
 end

--- a/spec/lib/aba/batch_spec.rb
+++ b/spec/lib/aba/batch_spec.rb
@@ -131,18 +131,5 @@ describe Aba::Batch do
         expect(batch.errors).to eq(:entries => { 1 => ["amount must be a number"], 2 => ["amount must be a number"] })
       end
     end
-
-    context "with an invalid total (exceeding 10 characters)" do
-      let(:transactions_attributes) do
-        [
-          {amount: 9999999999, transaction_code: 50},
-          {amount: 9999999999, transaction_code: 50},
-        ]
-      end
-
-      it "reports the errors" do
-        expect(batch.errors).to include(aba: ["total length must not exceed 10 characters"])
-      end
-    end
   end
 end

--- a/spec/lib/aba/return_spec.rb
+++ b/spec/lib/aba/return_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 require "spec_helper"

--- a/spec/lib/aba/transaction_spec.rb
+++ b/spec/lib/aba/transaction_spec.rb
@@ -44,10 +44,15 @@ describe Aba::Transaction do
       expect(subject.valid?).to eq true
     end
 
-    it "should not be valid" do
-      transaction_params.delete(:bsb)
-      expect(subject.valid?).to eq false
-      expect(subject.errors).to eq ["bsb format is incorrect"]
+    context "without bsb param" do
+      before do
+        transaction_params.delete(:bsb)
+      end
+
+      it "is invalid" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors).to eq ["bsb format is incorrect"]
+      end
     end
   end
 end

--- a/spec/lib/aba/transaction_spec.rb
+++ b/spec/lib/aba/transaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 require "spec_helper"

--- a/spec/lib/aba/transaction_spec.rb
+++ b/spec/lib/aba/transaction_spec.rb
@@ -54,5 +54,21 @@ describe Aba::Transaction do
         expect(subject.errors).to eq ["bsb format is incorrect"]
       end
     end
+
+    describe ":amount" do
+      subject(:transaction) { Aba::Transaction.new(transaction_params.merge(amount: amount)) }
+
+      context "with 10 digits" do
+        let(:amount) { "1234567890" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "with 11 digits" do
+        let(:amount) { "12345678901" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
   end
 end

--- a/spec/lib/aba/validations_spec.rb
+++ b/spec/lib/aba/validations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 require "spec_helper"

--- a/spec/lib/aba_spec.rb
+++ b/spec/lib/aba_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 require "spec_helper"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 Bundler.setup
 


### PR DESCRIPTION
### Context

ABA files impose a 10-character limit on amounts and credit/debit total amounts. 

### Change
- Apply validations to reflect this limitation. 
- Sprinkle magic `frozen_string_literal` comments throughout. 🪄 
- Bump version and update changelog.